### PR TITLE
Fix issue with itemetadata for OX and ESX

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -83,11 +83,12 @@ end
 
 -- Handles creating and placing the bike in the world
 -- Adds a plate to the bike (either from the item metadata or a random plate) and sets the player as the owner/gives keys
--- bikeItem info may be nil for frameworks that don't support item metadata (ex: ESX)
+-- bikeItemData info may be nil for frameworks that don't support item metadata (ex: ESX)
 ---@param bikeModel string The model of the bike to spawn
----@param bikeItem table The item data of the bike to spawn
-RegisterNetEvent('wp-pocketbikes:client:place', function(bikeModel, bikeItem)
+---@param bikeItemData table The item data of the bike to spawn
+RegisterNetEvent('wp-pocketbikes:client:place', function(bikeModel, bikeItemData)
     local ped = PlayerPedId()
+    local itemMetadata = GetItemMetadata(bikeItemData)
 
     -- Request model and wait until its loaded
     LoadModel(bikeModel)
@@ -105,13 +106,13 @@ RegisterNetEvent('wp-pocketbikes:client:place', function(bikeModel, bikeItem)
 
     TriggerServerEvent("wp-pocketbikes:server:RemoveItem", bikeModel)
 
-    setBikeProperties(bike, bikeItem.info)
+    setBikeProperties(bike, itemMetadata)
     
     SetModelAsNoLongerNeeded(bikeModel)
 
     local bikePlate = GetVehicleNumberPlateText(bike)
-    if bikeItem.info then
-        bikePlate = bikeItem.info.plate
+    if itemMetadata then
+        bikePlate = itemMetadata.plate
     end
     SetPlayerAsOwnerOfVehicleWithPlate(bikePlate)
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game 'gta5'
 
 description 'Waypoint Pocket Bikes'
 author 'BackSH00TER - Waypoint RP'
-version '1.0.1'
+version '1.0.2'
 
 shared_script {
     -- '@ox_lib/init.lua', -- Uncomment this if you are planning to use any ox scripts (such as ox notify)

--- a/shared/framework.lua
+++ b/shared/framework.lua
@@ -86,6 +86,20 @@ end
 
 --------------------- CLIENT FUNCTIONS ---------------------
 
+-- Returns the item metadata
+---@param itemData table The item data from using the item
+---@return table The metadata of the item
+function GetItemMetadata(itemData) 
+    if Config.Inventory == 'esx' then
+        -- ESX inventory does not support metadata by default, recommended to use ox_inventory instead
+        print("GetItemMetadata is missing an implementation in the framework file for esx")
+    elseif Config.Inventory == 'qb' then
+        return itemData.info
+    elseif Config.Inventory == 'ox' then
+        return itemData.metadata
+    end
+end
+
 -- Gives the player keys and sets them as the "owner" of the vehicle
 ---@param plate string The plate of the vehicle to give keys to
 function SetPlayerAsOwnerOfVehicleWithPlate(plate)
@@ -124,7 +138,8 @@ end
 ---@param source number The source of the player
 ---@param itemName string The name of the item to add
 ---@param amount number The amount of the item to add
-function AddItem(source, itemName, amount)
+---@param info table Metadata to add to the item
+function AddItem(source, itemName, amount, info)
     if not IsDuplicityVersion() then return end
     if Config.Inventory == 'esx' then
         local xPlayer = Core.GetPlayerFromId(source)
@@ -132,9 +147,9 @@ function AddItem(source, itemName, amount)
     elseif Config.Inventory == 'qb' then
         local Player = Core.Functions.GetPlayer(source)
         TriggerClientEvent('inventory:client:ItemBox', source, Core.Shared.Items[itemName], "add")
-        return Player.Functions.AddItem(itemName, amount) 
+        return Player.Functions.AddItem(itemName, amount, nil, info) 
     elseif Config.Inventory == 'ox' then
-        exports.ox_inventory:AddItem(source, itemName, amount)
+        exports.ox_inventory:AddItem(source, itemName, amount, info)
     end
 end
 

--- a/shared/framework.lua
+++ b/shared/framework.lua
@@ -102,12 +102,21 @@ end
 
 --------------------- SERVER FUNCTIONS ---------------------
 
-function CreateUseableItem(...)
+-- Registers a useable item
+---@param itemName string The name of the item to register
+---@param callbackFn function The function to call when the item is used
+function CreateUseableItem(itemName, callbackFn)
     if not IsDuplicityVersion() then return end
     if Config.Framework == 'esx' then
-        return Core.RegisterUsableItem(...)
+        -- ESX returns the itemName as the second parameter, itemdata as the third parameter when calling the callback function
+        -- We are interested in the itemData for our callback
+        local function ESXCallback(source, itemName, itemData) 
+            callbackFn(source, itemData)
+        end
+
+        return Core.RegisterUsableItem(itemName, ESXCallback)
     elseif Config.Framework == 'qb' then
-        return Core.Functions.CreateUseableItem(...)
+        return Core.Functions.CreateUseableItem(itemName, callbackFn)
     end
 end
 


### PR DESCRIPTION
- Fixed CreateUseableItem framework implementation for ESX since it uses a third argument to pass the itemmetadata (instead of the second arg)
- Fixed itemmetadata for ox inv

Tested on servers with esx + ox, qb + ox, and qb only 