### PR TITLE
Add a check for ox_lib in the manifest

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ game "gta5"
 
 description "Waypoint Pocket Bikes"
 author "BackSH00TER - Waypoint RP"
-version "1.0.4"
+version "1.0.5"
 
 shared_script {
     -- '@ox_lib/init.lua', -- Uncomment this if you are planning to use any ox scripts (such as ox notify)

--- a/server.lua
+++ b/server.lua
@@ -14,3 +14,12 @@ RegisterNetEvent("wp-pocketbikes:server:AddItem", function(itemName, itemInfo)
     local src = source
     AddItem(src, itemName, 1, itemInfo)
 end)
+
+AddEventHandler("onResourceStart", function(resourceName)
+    if resourceName == GetCurrentResourceName() then
+        -- Give the script some time to start
+        Wait(100)
+
+        ValidateOxLibUsage()
+    end
+end)

--- a/shared/framework.lua
+++ b/shared/framework.lua
@@ -185,3 +185,61 @@ function RemoveItem(source, itemName, amount, slot)
         warn("Invalid Config.Inventory: <" .. tostring(Config.Inventory) .. ">. Update RemoveItem in framework.lua.")
     end
 end
+
+--- This function checks if any OX scripts are being used in the configuration
+--- and throws an error if `ox_lib` is not properly enabled in the `fxmanifest.lua`.
+--- 
+--- **Usage**: Call this function on the server inside an `onResourceStart` event handler.
+--- 
+--- **Example**:
+--- ```lua
+--- AddEventHandler("onResourceStart", function(resourceName)
+---     if GetCurrentResourceName() == resourceName then
+---         Wait(100) -- Give the script some time to start
+---         ValidateOxLibUsage()
+---     end
+--- end)
+--- ```
+function ValidateOxLibUsage()
+    if not IsDuplicityVersion() then return end
+
+    local isUsingOxScripts =
+        Config.Notify == "ox"
+        or Config.Target == "ox"
+        or Config.Inventory == "ox"
+
+    -- Ensure ox_lib is not commented out in the fxmanifest/shared_script section if any OX scripts are used in the Config.
+    -- If ox_lib is commented out, display an error as the script will not function correctly.
+    if isUsingOxScripts then
+        local filePath = GetResourcePath(GetCurrentResourceName()) .. "/fxmanifest.lua"
+        local file, _errorMsg = io.open(filePath, "r")
+        if not file then return end
+
+        -- Read through the fxmanifest file
+        -- Find the line with "@ox_lib/init.lua" and check if it is commented out
+        local isOxLibCommentedOut = false
+        for line in file:lines() do
+            if line:find("@ox_lib/init.lua") then
+                -- Check if the line is commented out
+                if line:match("^%s*%-%-") then
+                    isOxLibCommentedOut = true
+                end
+                break
+            end
+        end
+
+        file:close()
+
+        if isOxLibCommentedOut then
+            error(
+                "\n=====================================\n\n" ..
+
+                "YOU ARE USING OX SCRIPTS AND DID NOT UNCOMMENT OX_LIB IN THE FXMANIFEST!\n\n" ..
+
+                "The script will not work until you uncomment it from the fxmanifest.\n\n" ..
+
+                "=====================================\n"
+            )
+        end
+    end
+end


### PR DESCRIPTION
- Implemented a check on resource start to verify if any of the config script options are set to "ox". If so, it ensures that @ox_lib/init.lua is not commented out in the shared_script section of the fxmanifest.
- If it is commented out, a critical error is displayed.
- Added a new `ValidateOxLibUsage()` function in `shared/framework.lua` to run this check.
- This change aims to reduce the number of support tickets created for this recurring issue, despite it being clearly mentioned in the setup instructions and the config file in multiple places.